### PR TITLE
Updated to work with current insight timer log duration format (hh:mm:ss)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,13 @@ Notes
 ------
 This script will only retrieve today's minutes. If you want to post yesterday's minutes that is currently unsupported.
 
+It also only posts minutes for log entries containing the word "Meditation". 
+
 If you run the script more than once it will post duplicate entries.
 
 Change Log
 ------
+2018-08-18: Updated to be compatible with changed Insight Timer log format that uses hh:mm:ss instead of just minutes in the duration part.
 2016-02-02: Merged Josh Curtis fork. Bug fixes:
             - Timezone correction now works on the 1st of the month
 			- Script will now gracefully handle data where there are fewer than 4 sessions recorded.

--- a/beesight.py
+++ b/beesight.py
@@ -119,7 +119,12 @@ def csv_to_todays_minutes(csv_lines):
         for l in csv_lines[2:6]:
             line = l.split(",")
             datetime_part = line[0]
-            minutes_entry = line[1]
+            duration_part = line[1]
+            activity_part = line[2]
+            if "Meditation" not in activity_part:
+                continue 
+            d_h, d_m, d_s= duration_part.split(":")
+            minutes_entry = 60 * int(d_h) + int(d_m) + (1 if int(d_s) >= 30 else 0)
             logger.info ("%s : %s minutes", datetime_part, minutes_entry)
             date_part, time_part = datetime_part.split(" ")
             date_parts = date_part.split("/")


### PR DESCRIPTION
I started trying to use this and was getting errors as python couldn't cast the minutes_entry part as an int - because the relevant part of the log file contained something like 00:20:00 instead of just an integer. I guess Insight Timer have changed their log format to loh hours and seconds as well as minutes since tthis was written?

I have updated to make it work now.